### PR TITLE
Attempt to fix race condition in MessageBusMalamute

### DIFF
--- a/src/fty_common_messagebus_malamute.h
+++ b/src/fty_common_messagebus_malamute.h
@@ -60,6 +60,11 @@ namespace messagebus {
         Message request(const std::string& requestQueue, const Message& message, int receiveTimeOut) override;
         
       private:
+        int client_set_producer(const char *stream);
+        int client_set_consumer(const char *stream, const char *pattern);
+        int client_send(const char *subject, zmsg_t **content);
+        int client_sendto(const char *address, const char *subject, const char *tracker, uint32_t timeout, zmsg_t **content);
+
         static void listener(zsock_t *pipe, void* ptr);
         void listenerMainloop(zsock_t *pipe);
         void listenerHandleMailbox (const char *, const char *, zmsg_t *);
@@ -71,6 +76,8 @@ namespace messagebus {
         std::string   m_publishTopic;
 
         zactor_t     *m_actor;
+        std::mutex    m_actor_mtx;
+
         std::map<std::string, MessageListener> m_subscriptions;
 
         std::condition_variable m_cv;


### PR DESCRIPTION
RPC all mlm_client_* calls through the listener thread. This is probably not enough to fix all issues with this library, but clients at least seem to receive a timeout exception instead of hanging forever.